### PR TITLE
fix: update contact information and URLs to current standards

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ or products provided by Revenium Metering, please follow the respective company'
 
 ### Revenium Metering Terms and Policies
 
-Please contact info@revenium.io for any questions or concerns regarding the security of our services.
+Please contact support@revenium.io for any questions or concerns regarding the security of our services.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The official Python library for the revenium-metering API"
 dynamic = ["readme"]
 license = "MIT"
 authors = [
-{ name = "Revenium Metering", email = "info@revenium.io" },
+{ name = "Revenium Metering", email = "support@revenium.io" },
 ]
 dependencies = [
     "httpx>=0.23.0, <1",


### PR DESCRIPTION
## Summary
Updates contact email addresses and website URLs per organizational standards.

## Changes
- Changed `info@revenium.io` → `support@revenium.io`
- Changed `security@revenium.io` → `support@revenium.io` (where applicable)
- Changed `revenium.io` URLs → `revenium.ai` (where applicable)
- Preserved `docs.revenium.io` (correct URL)

## Related
Closes BACK-493