### PR TITLE
feat(ai): add multimodal metering fields

### DIFF
--- a/src/revenium_metering/resources/ai.py
+++ b/src/revenium_metering/resources/ai.py
@@ -106,6 +106,7 @@ class AIResource(SyncAPIResource):
         input_messages: str | NotGiven = NOT_GIVEN,
         output_response: str | NotGiven = NOT_GIVEN,
         prompts_truncated: bool | NotGiven = NOT_GIVEN,
+        has_vision_content: bool | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -292,6 +293,7 @@ class AIResource(SyncAPIResource):
                     "input_messages": input_messages,
                     "output_response": output_response,
                     "prompts_truncated": prompts_truncated,
+                    "has_vision_content": has_vision_content,
                 },
                 ai_create_completion_params.AICreateCompletionParams,
             ),
@@ -574,6 +576,7 @@ class AIResource(SyncAPIResource):
         middleware_source: str | NotGiven = NOT_GIVEN,
         model_source: str | NotGiven = NOT_GIVEN,
         credential_alias: str | NotGiven = NOT_GIVEN,
+        aspect_ratio: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -663,6 +666,8 @@ class AIResource(SyncAPIResource):
 
           credential_alias: Human-readable name for the API key being used
 
+          aspect_ratio: Aspect ratio of the generated video (e.g., '16:9', '9:16', '1:1')
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -714,6 +719,7 @@ class AIResource(SyncAPIResource):
                     "middleware_source": middleware_source,
                     "model_source": model_source,
                     "credential_alias": credential_alias,
+                    "aspect_ratio": aspect_ratio,
                 },
                 ai_create_video_params.AICreateVideoParams,
             ),
@@ -766,6 +772,7 @@ class AIResource(SyncAPIResource):
         middleware_source: str | NotGiven = NOT_GIVEN,
         model_source: str | NotGiven = NOT_GIVEN,
         credential_alias: str | NotGiven = NOT_GIVEN,
+        aspect_ratio: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -853,6 +860,8 @@ class AIResource(SyncAPIResource):
 
           credential_alias: Human-readable name for the API key being used
 
+          aspect_ratio: Aspect ratio of the generated image (e.g., '1:1', '16:9', '9:16')
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -903,6 +912,7 @@ class AIResource(SyncAPIResource):
                     "middleware_source": middleware_source,
                     "model_source": model_source,
                     "credential_alias": credential_alias,
+                    "aspect_ratio": aspect_ratio,
                 },
                 ai_create_image_params.AICreateImageParams,
             ),
@@ -991,6 +1001,7 @@ class AsyncAIResource(AsyncAPIResource):
         input_messages: str | NotGiven = NOT_GIVEN,
         output_response: str | NotGiven = NOT_GIVEN,
         prompts_truncated: bool | NotGiven = NOT_GIVEN,
+        has_vision_content: bool | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -1177,6 +1188,7 @@ class AsyncAIResource(AsyncAPIResource):
                     "input_messages": input_messages,
                     "output_response": output_response,
                     "prompts_truncated": prompts_truncated,
+                    "has_vision_content": has_vision_content,
                 },
                 ai_create_completion_params.AICreateCompletionParams,
             ),
@@ -1459,6 +1471,7 @@ class AsyncAIResource(AsyncAPIResource):
         middleware_source: str | NotGiven = NOT_GIVEN,
         model_source: str | NotGiven = NOT_GIVEN,
         credential_alias: str | NotGiven = NOT_GIVEN,
+        aspect_ratio: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -1548,6 +1561,8 @@ class AsyncAIResource(AsyncAPIResource):
 
           credential_alias: Human-readable name for the API key being used
 
+          aspect_ratio: Aspect ratio of the generated video (e.g., '16:9', '9:16', '1:1')
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -1599,6 +1614,7 @@ class AsyncAIResource(AsyncAPIResource):
                     "middleware_source": middleware_source,
                     "model_source": model_source,
                     "credential_alias": credential_alias,
+                    "aspect_ratio": aspect_ratio,
                 },
                 ai_create_video_params.AICreateVideoParams,
             ),
@@ -1651,6 +1667,7 @@ class AsyncAIResource(AsyncAPIResource):
         middleware_source: str | NotGiven = NOT_GIVEN,
         model_source: str | NotGiven = NOT_GIVEN,
         credential_alias: str | NotGiven = NOT_GIVEN,
+        aspect_ratio: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -1738,6 +1755,8 @@ class AsyncAIResource(AsyncAPIResource):
 
           credential_alias: Human-readable name for the API key being used
 
+          aspect_ratio: Aspect ratio of the generated image (e.g., '1:1', '16:9', '9:16')
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -1788,6 +1807,7 @@ class AsyncAIResource(AsyncAPIResource):
                     "middleware_source": middleware_source,
                     "model_source": model_source,
                     "credential_alias": credential_alias,
+                    "aspect_ratio": aspect_ratio,
                 },
                 ai_create_image_params.AICreateImageParams,
             ),

--- a/src/revenium_metering/types/ai_create_completion_params.py
+++ b/src/revenium_metering/types/ai_create_completion_params.py
@@ -232,6 +232,9 @@ class AICreateCompletionParams(TypedDict, total=False):
     prompts_truncated: Annotated[bool, PropertyInfo(alias="promptsTruncated")]
     """Indicates if any prompt or response field was truncated due to length limits"""
 
+    has_vision_content: Annotated[bool, PropertyInfo(alias="hasVisionContent")]
+    """Indicates if the request contained vision/image content (e.g., Gemini Vision)"""
+
 
 class SubscriberCredential(TypedDict, total=False):
     name: str

--- a/src/revenium_metering/types/ai_create_image_params.py
+++ b/src/revenium_metering/types/ai_create_image_params.py
@@ -152,6 +152,9 @@ class AICreateImageParams(TypedDict, total=False):
     credential_alias: Annotated[str, PropertyInfo(alias="credentialAlias")]
     """Human-readable name for the API key being used"""
 
+    aspect_ratio: Annotated[str, PropertyInfo(alias="aspectRatio")]
+    """Aspect ratio of the generated image (e.g., '1:1', '16:9', '9:16')"""
+
 
 class SubscriberCredential(TypedDict, total=False):
     name: str

--- a/src/revenium_metering/types/ai_create_video_params.py
+++ b/src/revenium_metering/types/ai_create_video_params.py
@@ -155,6 +155,9 @@ class AICreateVideoParams(TypedDict, total=False):
     credential_alias: Annotated[str, PropertyInfo(alias="credentialAlias")]
     """Human-readable name for the API key being used"""
 
+    aspect_ratio: Annotated[str, PropertyInfo(alias="aspectRatio")]
+    """Aspect ratio of the generated video (e.g., '16:9', '9:16', '1:1')"""
+
 
 class SubscriberCredential(TypedDict, total=False):
     name: str


### PR DESCRIPTION
## Description
Add missing multimodal metering fields needed by the Google Python middleware (BACK-350) for Imagen, Veo, and Gemini Vision support.

## Key Changes
- Add `has_vision_content` (bool) to `create_completion` for flagging requests containing vision/image content (e.g., Gemini Vision)
- Add `aspect_ratio` (str) to `create_image` for tracking image aspect ratios (e.g., '1:1', '16:9')
- Add `aspect_ratio` (str) to `create_video` for tracking video aspect ratios (e.g., '16:9', '9:16')
- All fields added to both sync and async resource methods, TypedDict params, body dicts, and docstrings
- PropertyInfo aliases ensure correct camelCase serialization (`hasVisionContent`, `aspectRatio`)

## Type of Change
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Documentation update
- [ ] Breaking change

## How to Test

- Run the following against the dev API:
```python
from revenium_metering import ReveniumMetering
client = ReveniumMetering(api_key="...", base_url="https://api.dev.hcapp.io")

# Test has_vision_content on completion
client.ai.create_completion(
    model="gemini-2.0-flash-001", provider="Google",
    input_token_count=269, output_token_count=1, total_token_count=270,
    cost_type="AI", request_duration=2000,
    request_time="2026-02-25T00:00:00Z", response_time="2026-02-25T00:00:02Z",
    completion_start_time="2026-02-25T00:00:02Z",
    stop_reason="END", transaction_id="test-1", is_streamed=False,
    has_vision_content=True,
)

# Test aspect_ratio on image
client.ai.create_image(
    model="imagen-3.0-generate-001", provider="Google",
    request_duration=5000,
    request_time="2026-02-25T00:00:00Z", response_time="2026-02-25T00:00:05Z",
    transaction_id="test-2",
    requested_image_count=1, actual_image_count=1,
    aspect_ratio="16:9",
)

# Test aspect_ratio on video
client.ai.create_video(
    model="veo-2.0-generate-001", provider="Google",
    request_duration=30000,
    request_time="2026-02-25T00:00:00Z", response_time="2026-02-25T00:00:30Z",
    transaction_id="test-3",
    duration_seconds=5.0,
    aspect_ratio="9:16",
)
```
- All 3 calls should return a valid `MeteringResponseResource` with an `id`

## Checklist
- [x] My code follows the style guidelines
- [x] New dependencies documented
- [x] I have performed a self-review of my code
- [x] I have added or updated tests that prove my fix is effective or my feature works