### PR TITLE
[SKIP-BOTS] chore: add greptile.json to enable PR title skip

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "ignoreKeywords": "[SKIP-BOTS]"
+}


### PR DESCRIPTION
Adds `greptile.json` to configure Greptile to skip automated reviews on any PR whose title contains `[SKIP-BOTS]`.

This is a no-op for all existing PRs — it only suppresses Greptile on PRs you explicitly opt out of by adding `[SKIP-BOTS]` to the title.

Related: [PRODUCT-1535](https://linear.app/revenium/issue/PRODUCT-1535)